### PR TITLE
Support for exporting if-else statements in JsonLogic format (requires custom firstMatch JsonLogic operator)

### DIFF
--- a/modules/export/jsonLogic.js
+++ b/modules/export/jsonLogic.js
@@ -150,9 +150,11 @@ const jsonLogicFormatItem = (item, config, meta) => {
         let resultQuery
 
         if (list.size == 1) {
-            resultQuery = list.first();
+          resultQuery = list.first();
+        } else if (conj === 'if') { // handle if together with rule actions
+          resultQuery = list.toList().toJS();
         } else {
-            resultQuery[conj] = list.toList().toJS();
+          resultQuery = { [conj]: list.toList().toJS() }
         }
 
         if (not) {
@@ -167,7 +169,15 @@ const jsonLogicFormatItem = (item, config, meta) => {
             ra.get('properties').get('value')
           )).toJS())
 
-          resultQuery = { "merge": [ resultQuery, ruleActionsValues, [] ] }
+          if (conj === 'if') {
+            if (!Array.isArray(resultQuery)) {
+              resultQuery = [ resultQuery ]
+            }
+
+            resultQuery = { firstMatch: [ ...resultQuery, ruleActionsValues ] }
+          } else {
+            resultQuery = { if: [ resultQuery, ruleActionsValues, [] ] }
+          }
         }
 
         return resultQuery;


### PR DESCRIPTION
### Features complete
- [x] can export if-elif-else statements as JsonLogic
	- requires custom firstMatch JsonLogic operator - firstMatch works just like `Array.find(elem => !!elem)` i.e. returns first truthy element (in our case, it will be the first non-empty array)

### Screenshot
<img width="1424" alt="Screen Shot 2020-01-20 at 2 52 32 PM" src="https://user-images.githubusercontent.com/44253687/72701987-87eee380-3b94-11ea-99e6-64db935b1551.png">

### JsonLogic output for screenshot's config

```
{
  "firstMatch": [
    {
      "merge": [
        {
          "if": [
            {
              ">": [
                {
                  "var": "price"
                },
                50000
              ]
            },
            [
              "sendToJ"
            ],
            []
          ]
        },
        {
          "if": [
            {
              "==": [
                {
                  "var": "price"
                },
                125125
              ]
            },
            [
              "setManual"
            ],
            []
          ]
        }
      ]
    },
    {
      "if": [
        {
          "and": [
            {
              "==": [
                {
                  "var": "price"
                },
                555
              ]
            },
            {
              "==": [
                {
                  "var": "price"
                },
                123123
              ]
            }
          ]
        },
        [
          "setManual"
        ],
        []
      ]
    },
    [
      "setManual"
    ]
  ]
}
```

